### PR TITLE
Fixed version conflict with dart 2.1.0/flutter 0.6

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -7,6 +7,9 @@ homepage: https://github.com/a2en/flutter_google_place_picker
 dependencies:
   flutter:
     sdk: flutter
+    
+environment:
+  sdk: ">=2.0.0-dev.58.0 <3.0.0"
 
 # For information on the generic Dart part of this file, see the
 # following page: https://www.dartlang.org/tools/pub/pubspec


### PR DESCRIPTION
Check https://github.com/flutter/flutter/issues/20700 for more info.

Issue is resolved by just setting a minimum environment version for the
plugin.

Closes:
https://github.com/a2en/flutter_google_place_picker/issues/2